### PR TITLE
Potential fix for code scanning alert no. 10: Imprecise assert

### DIFF
--- a/test/function_test.py
+++ b/test/function_test.py
@@ -147,7 +147,7 @@ class TestFunctions(unittest.TestCase):
                                                'URLs Affected': 2}}
         check_text = "Alert potentially resolved"
         result = compare_zap_results(this_dict, comp_dict, THIS_DATE, COMP_DATE)
-        self.assertTrue(check_text in result)
+        self.assertIn(check_text, result)
 
     def test_get_alert_table_row_same(self):
         """This test verifies that get alert table row returns the row correctly."""


### PR DESCRIPTION
Potential fix for [https://github.com/Accruent/owasp-zap-historic-parser/security/code-scanning/10](https://github.com/Accruent/owasp-zap-historic-parser/security/code-scanning/10)

Replace the imprecise membership assertion with `assertIn` in `test/function_test.py` at the `test_compare_zap_results_resolved` test (line 150 in the provided snippet).

- **General fix approach:** convert `assertTrue(x in y)` to `assertIn(x, y)` (or `assertNotIn` for negated forms) when no custom message is provided.
- **Best specific fix here:** change:
  - `self.assertTrue(check_text in result)`
  - to `self.assertIn(check_text, result)`
- **Scope:** only the flagged line in `test/function_test.py`.
- **No imports/dependencies/methods** are needed; `assertIn` is already part of `unittest.TestCase`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
